### PR TITLE
Add index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ node_modules/
 /log/
 /lib/typings/
 git-info.json
-/index.ts

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2020 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// lib
+export {} from "./lib/bundle";
+export { buttonForCommand, menuForCommand } from "./lib/button";
+export {
+    execPromise,
+    spawnPromise,
+    killProcess,
+    SpawnPromiseOptions,
+    SpawnPromiseReturns,
+    WritableLog,
+} from "./lib/child_process";
+export {} from "./lib/context";
+export {} from "./lib/function";
+export { GraphQLClient, QueryOrLocation, Location } from "./lib/graphql";
+export {
+    Contextual,
+    CommandContext,
+    CommandHandler,
+    Configuration,
+    EventContext,
+    EventHandler,
+    HandlerStatus,
+} from "./lib/handler";
+export { HttpClient } from "./lib/http";
+export { debug, error, info, warn } from "./lib/log";
+export {
+    CommandMessageClient,
+    MessageClient,
+    RequiredMessageOptions,
+    MessageOptions,
+    Destinations,
+    SlackFileMessage,
+} from "./lib/message";
+export {
+    slackErrorMessage,
+    slackFooter,
+    slackInfoMessage,
+    slackSeparator,
+    slackSupportLink,
+    slackSuccessMessage,
+    slackTs,
+    slackQuestionMessage,
+    slackWarningMessage,
+} from "./lib/messages";
+export {
+    ParameterPrompt,
+    ParametersPromptObject,
+    ParameterPromptOptions,
+    ParameterPromptStyle,
+} from "./lib/parameter_prompt";
+export { BaseParameter, Option, Options, Parameter, ParametersObjectValue, HasDefaultValue } from "./lib/parameters";
+export {} from "./lib/payload";
+export {
+    ProjectLoader,
+    CloneOptions,
+    AuthenticatedRepositoryId,
+    gitHubComRepository,
+    RepositoryId,
+    RepositoryProviderType,
+} from "./lib/project";
+export { DEFAULT_REDACTION_PATTERNS, redact } from "./lib/redact";
+export { linkedRepositories, linkedRepository } from "./lib/repository";
+export * from "./lib/resource_providers";
+export {
+    GitHubAppCredential,
+    GitHubCredential,
+    gitHubAppToken,
+    gitHubUserToken,
+    CredentialProvider,
+    CredentialResolver,
+} from "./lib/secrets";
+export * from "./lib/skill";
+export { runSteps, Step, StepListener } from "./lib/steps";
+export { StorageProvider } from "./lib/storage";
+export { guid, handleError, handleErrorSync, hideString, toArray, replacer } from "./lib/util";
+
+// lib/project
+export {} from "./lib/project/clone";
+export * as git from "./lib/project/git";
+export * as github from "./lib/project/github";
+export {} from "./lib/project/gitStatus";
+export { Project, Exec, Spawn } from "./lib/project/project";
+export { cwd, globFiles, withGlobMatches } from "./lib/project/util";
+
+// lib/scripts
+export {} from "./lib/scripts/gql_fetch";
+export {} from "./lib/scripts/skill_bundle";
+export {} from "./lib/scripts/skill_clean";
+export {} from "./lib/scripts/skill_container";
+export {} from "./lib/scripts/skill_input";
+export {} from "./lib/scripts/skill_invoke";
+export {} from "./lib/scripts/skill_package";
+export {} from "./lib/scripts/skill_register";
+export {} from "./lib/scripts/skill_run";

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,7 @@ export {
     HandlerStatus,
 } from "./lib/handler";
 export { HttpClient } from "./lib/http";
-export { debug, error, info, warn } from "./lib/log";
+export { log } from "./lib/log";
 export {
     CommandMessageClient,
     MessageClient,
@@ -47,17 +47,7 @@ export {
     Destinations,
     SlackFileMessage,
 } from "./lib/message";
-export {
-    slackErrorMessage,
-    slackFooter,
-    slackInfoMessage,
-    slackSeparator,
-    slackSupportLink,
-    slackSuccessMessage,
-    slackTs,
-    slackQuestionMessage,
-    slackWarningMessage,
-} from "./lib/messages";
+export { slack } from "./lib/messages";
 export {
     ParameterPrompt,
     ParametersPromptObject,

--- a/lib/bundle.ts
+++ b/lib/bundle.ts
@@ -14,25 +14,10 @@
  * limitations under the License.
  */
 
-import {
-    processCommand,
-    processEvent,
-    PubSubMessage,
-} from "./function";
-import {
-    CommandHandler,
-    EventHandler,
-} from "./handler";
-import {
-    debug,
-    info,
-} from "./log";
-import {
-    CommandIncoming,
-    EventIncoming,
-    isCommandIncoming,
-    isEventIncoming,
-} from "./payload";
+import { processCommand, processEvent, PubSubMessage } from "./function";
+import { CommandHandler, EventHandler } from "./handler";
+import { debug, info } from "./log";
+import { CommandIncoming, EventIncoming, isCommandIncoming, isEventIncoming } from "./payload";
 import { replacer } from "./util";
 
 const HandlerRegistry = {

--- a/lib/child_process.ts
+++ b/lib/child_process.ts
@@ -14,17 +14,9 @@
  * limitations under the License.
  */
 
-import {
-    SpawnOptions,
-    SpawnSyncOptions,
-    SpawnSyncReturns,
-} from "child_process";
+import { SpawnOptions, SpawnSyncOptions, SpawnSyncReturns } from "child_process";
 import * as process from "process";
-import {
-    debug,
-    error,
-    warn,
-} from "./log";
+import { debug, error, warn } from "./log";
 
 /**
  * Convert child process into an informative string.

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -16,25 +16,12 @@
 
 import * as fs from "fs-extra";
 import { createGraphQLClient } from "./graphql";
-import {
-    CommandContext,
-    Configuration,
-    EventContext,
-} from "./handler";
+import { CommandContext, Configuration, EventContext } from "./handler";
 import { createHttpClient } from "./http";
 import { wrapAuditLogger } from "./log";
-import {
-    PubSubCommandMessageClient,
-    PubSubEventMessageClient,
-} from "./message";
+import { PubSubCommandMessageClient, PubSubEventMessageClient } from "./message";
 import { commandRequestParameterPromptFactory } from "./parameter_prompt";
-import {
-    CommandIncoming,
-    EventIncoming,
-    isCommandIncoming,
-    isEventIncoming,
-    workspaceId,
-} from "./payload";
+import { CommandIncoming, EventIncoming, isCommandIncoming, isEventIncoming, workspaceId } from "./payload";
 import { createProjectLoader } from "./project";
 import { ClonePath } from "./project/clone";
 import { DefaultCredentialProvider } from "./secrets";

--- a/lib/function.ts
+++ b/lib/function.ts
@@ -19,32 +19,12 @@ import "source-map-support/register";
 
 import { Severity } from "@atomist/skill-logging";
 import { createContext } from "./context";
-import {
-    CommandContext,
-    CommandHandler,
-    EventContext,
-    EventHandler,
-    HandlerStatus,
-} from "./handler";
-import {
-    debug,
-    info,
-} from "./log";
-import {
-    prepareStatus,
-    StatusPublisher,
-} from "./message";
+import { CommandContext, CommandHandler, EventContext, EventHandler, HandlerStatus } from "./handler";
+import { debug, info } from "./log";
+import { prepareStatus, StatusPublisher } from "./message";
 import { CommandListenerExecutionInterruptError } from "./parameter_prompt";
-import {
-    CommandIncoming,
-    EventIncoming,
-    isCommandIncoming,
-    isEventIncoming,
-} from "./payload";
-import {
-    handlerLoader,
-    replacer,
-} from "./util";
+import { CommandIncoming, EventIncoming, isCommandIncoming, isEventIncoming } from "./payload";
+import { handlerLoader, replacer } from "./util";
 
 export interface PubSubMessage {
     data: string;

--- a/lib/handler.ts
+++ b/lib/handler.ts
@@ -17,18 +17,9 @@
 import { Logger } from "@atomist/skill-logging/lib/logging";
 import { GraphQLClient } from "./graphql";
 import { HttpClient } from "./http";
-import {
-    CommandMessageClient,
-    MessageClient,
-} from "./message";
-import {
-    ParameterPromptOptions,
-    ParametersPromptObject,
-} from "./parameter_prompt";
-import {
-    CommandIncoming,
-    EventIncoming,
-} from "./payload";
+import { CommandMessageClient, MessageClient } from "./message";
+import { ParameterPromptOptions, ParametersPromptObject } from "./parameter_prompt";
+import { CommandIncoming, EventIncoming } from "./payload";
 import { ProjectLoader } from "./project";
 import { CredentialProvider } from "./secrets";
 import { StorageProvider } from "./storage";

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    RequestInit,
-    Response,
-} from "node-fetch";
+import { RequestInit, Response } from "node-fetch";
 
 export interface HttpClient {
     request<T>(url: string, options: RequestInit): Promise<Response & { json(): Promise<T> }>;

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -112,3 +112,10 @@ function enabled(level: string): boolean {
     const configuredLevel = Level[process.env.ATOMIST_LOG_LEVEL || "debug"];
     return configuredLevel >= Level[level];
 }
+
+export const log = {
+    debug,
+    error,
+    info,
+    warn,
+};

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    createLogger,
-    Logger,
-    Severity,
-} from "@atomist/skill-logging";
+import { createLogger, Logger, Severity } from "@atomist/skill-logging";
 import { redact } from "./redact";
 import { toArray } from "./util";
 

--- a/lib/message.ts
+++ b/lib/message.ts
@@ -14,34 +14,14 @@
  * limitations under the License.
  */
 
-import {
-    render,
-    SlackMessage,
-} from "@atomist/slack-messages";
+import { render, SlackMessage } from "@atomist/slack-messages";
 import { Action as SlackAction } from "@atomist/slack-messages/lib/SlackMessages";
 import { PubSub } from "@google-cloud/pubsub";
 import { GraphQLClient } from "./graphql";
-import {
-    CommandContext,
-    EventContext,
-    HandlerStatus,
-} from "./handler";
-import {
-    debug,
-    error,
-} from "./log";
-import {
-    CommandIncoming,
-    EventIncoming,
-    isCommandIncoming,
-    isEventIncoming,
-    Skill,
-    Source,
-} from "./payload";
-import {
-    replacer,
-    toArray,
-} from "./util";
+import { CommandContext, EventContext, HandlerStatus } from "./handler";
+import { debug, error } from "./log";
+import { CommandIncoming, EventIncoming, isCommandIncoming, isEventIncoming, Skill, Source } from "./payload";
+import { replacer, toArray } from "./util";
 import cloneDeep = require("lodash.clonedeep");
 
 export interface Destinations {

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -156,3 +156,15 @@ export function slackTs(): number {
 export function slackSeparator(): string {
     return "\u00B7";
 }
+
+export const slack = {
+    errorMessage: slackErrorMessage,
+    footer: slackFooter,
+    infoMessage: slackInfoMessage,
+    separator: slackSeparator,
+    supportLink: slackSupportLink,
+    successMessage: slackSuccessMessage,
+    ts: slackTs,
+    questionMessage: slackQuestionMessage,
+    warningMessage: slackWarningMessage,
+};

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-    Attachment,
-    SlackMessage,
-    url,
-} from "@atomist/slack-messages";
+import { Attachment, SlackMessage, url } from "@atomist/slack-messages";
 import { Contextual } from "./handler";
 import { guid } from "./util";
 

--- a/lib/parameter_prompt.ts
+++ b/lib/parameter_prompt.ts
@@ -14,16 +14,9 @@
  * limitations under the License.
  */
 
-import {
-    CommandMessageClient,
-    HandlerResponse,
-    Parameter,
-} from "./message";
+import { CommandMessageClient, HandlerResponse, Parameter } from "./message";
 import { ParametersObjectValue } from "./parameters";
-import {
-    Arg,
-    CommandIncoming,
-} from "./payload";
+import { Arg, CommandIncoming } from "./payload";
 import cloneDeep = require("lodash.clonedeep");
 import map = require("lodash.map");
 import set = require("lodash.set");

--- a/lib/project.ts
+++ b/lib/project.ts
@@ -14,15 +14,8 @@
  * limitations under the License.
  */
 
-import {
-    clone,
-    load,
-    Project,
-} from "./project/project";
-import {
-    GitHubAppCredential,
-    GitHubCredential,
-} from "./secrets";
+import { clone, load, Project } from "./project/project";
+import { GitHubAppCredential, GitHubCredential } from "./secrets";
 
 export interface CloneOptions {
     /**

--- a/lib/project/clone.ts
+++ b/lib/project/clone.ts
@@ -19,10 +19,7 @@ import * as pRetry from "p-retry";
 import * as path from "path";
 import { execPromise } from "../child_process";
 import { debug } from "../log";
-import {
-    AuthenticatedRepositoryId,
-    CloneOptions,
-} from "../project";
+import { AuthenticatedRepositoryId, CloneOptions } from "../project";
 import { guid } from "../util";
 
 export const ClonePath = path.join(os.tmpdir(), "atm-clone");

--- a/lib/project/git.ts
+++ b/lib/project/git.ts
@@ -17,10 +17,7 @@
 import * as pRetry from "p-retry";
 import { execPromise } from "../child_process";
 import { debug } from "../log";
-import {
-    GitStatus,
-    runStatusIn,
-} from "./gitStatus";
+import { GitStatus, runStatusIn } from "./gitStatus";
 import { Project } from "./project";
 import { cwd } from "./util";
 import forOwn = require("lodash.forown");

--- a/lib/project/github.ts
+++ b/lib/project/github.ts
@@ -17,10 +17,7 @@
 import { Octokit } from "@octokit/rest"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Contextual } from "../handler";
 import { AuthenticatedRepositoryId } from "../project";
-import {
-    GitHubAppCredential,
-    GitHubCredential,
-} from "../secrets";
+import { GitHubAppCredential, GitHubCredential } from "../secrets";
 
 const DefaultGitHubApiUrl = "https://api.github.com/";
 

--- a/lib/project/project.ts
+++ b/lib/project/project.ts
@@ -24,10 +24,7 @@ import {
     SpawnPromiseReturns,
 } from "../child_process";
 import { debug } from "../log";
-import {
-    AuthenticatedRepositoryId,
-    CloneOptions,
-} from "../project";
+import { AuthenticatedRepositoryId, CloneOptions } from "../project";
 import { doClone } from "./clone";
 import { setUserConfig } from "./git";
 

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -15,10 +15,7 @@
  */
 
 import { CommandContext } from "./handler";
-import {
-    RepositoryId,
-    RepositoryProviderType,
-} from "./project";
+import { RepositoryId, RepositoryProviderType } from "./project";
 
 const LinkedRepositoriesQuery = `query LinkedRepositories($id: String!) {
   ChatChannel(channelId: $id) {

--- a/lib/scripts/gql_fetch.ts
+++ b/lib/scripts/gql_fetch.ts
@@ -18,10 +18,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import { createGraphQLClient } from "../graphql";
 import { info } from "../log";
-import {
-    apiKey,
-    wid,
-} from "./skill_register";
+import { apiKey, wid } from "./skill_register";
 
 const IntrospectionQuery = `query IntrospectionQuery {
   __schema {

--- a/lib/scripts/skill_bundle.ts
+++ b/lib/scripts/skill_bundle.ts
@@ -17,10 +17,7 @@
 import * as fs from "fs-extra";
 import * as path from "path";
 import { spawnPromise } from "../child_process";
-import {
-    debug,
-    info,
-} from "../log";
+import { debug, info } from "../log";
 import { withGlobMatches } from "../project/util";
 
 export async function bundleSkill(cwd: string, minify: boolean, sourceMap: boolean, verbose: boolean): Promise<void> {

--- a/lib/scripts/skill_container.ts
+++ b/lib/scripts/skill_container.ts
@@ -19,11 +19,7 @@ import * as yaml from "js-yaml";
 import * as path from "path";
 import { info } from "../log";
 import { packageJson } from "../skill";
-import {
-    AtomistSkillInput,
-    content,
-    icon,
-} from "./skill_input";
+import { AtomistSkillInput, content, icon } from "./skill_input";
 
 export async function createYamlSkillInput(cwd: string): Promise<AtomistSkillInput> {
     info(`Generating skill metadata...`);

--- a/lib/scripts/skill_input.ts
+++ b/lib/scripts/skill_input.ts
@@ -16,16 +16,10 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
-import {
-    error,
-    info,
-} from "../log";
+import { error, info } from "../log";
 import { withGlobMatches } from "../project/util";
 import { Skill } from "../skill";
-import {
-    handleError,
-    handlerLoader,
-} from "../util";
+import { handleError, handlerLoader } from "../util";
 import { createYamlSkillInput } from "./skill_container";
 import map = require("lodash.map");
 

--- a/lib/scripts/skill_invoke.ts
+++ b/lib/scripts/skill_invoke.ts
@@ -16,24 +16,10 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
-import {
-    processCommand,
-    processEvent,
-} from "../function";
-import {
-    CommandIncoming,
-    EventIncoming,
-    isCommandIncoming,
-    isEventIncoming,
-} from "../payload";
-import {
-    guid,
-    handlerLoader,
-} from "../util";
-import {
-    apiKey,
-    wid,
-} from "./skill_register";
+import { processCommand, processEvent } from "../function";
+import { CommandIncoming, EventIncoming, isCommandIncoming, isEventIncoming } from "../payload";
+import { guid, handlerLoader } from "../util";
+import { apiKey, wid } from "./skill_register";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const merge = require("lodash.merge");
 

--- a/lib/scripts/skill_register.ts
+++ b/lib/scripts/skill_register.ts
@@ -20,14 +20,8 @@ import * as os from "os";
 import * as path from "path";
 import * as semver from "semver";
 import { spawnPromise } from "../child_process";
-import {
-    createGraphQLClient,
-    GraphQLClient,
-} from "../graphql";
-import {
-    error,
-    info,
-} from "../log";
+import { createGraphQLClient, GraphQLClient } from "../graphql";
+import { error, info } from "../log";
 import * as git from "../project/git";
 import { GoogleCloudStorageProvider } from "../storage";
 import { AtomistSkillInput } from "./skill_input";

--- a/lib/scripts/skill_run.ts
+++ b/lib/scripts/skill_run.ts
@@ -15,14 +15,8 @@
  */
 
 import * as fs from "fs-extra";
-import {
-    processCommand,
-    processEvent,
-} from "../function";
-import {
-    isCommandIncoming,
-    isEventIncoming,
-} from "../payload";
+import { processCommand, processEvent } from "../function";
+import { isCommandIncoming, isEventIncoming } from "../payload";
 
 export async function runSkill(skill?: string): Promise<void> {
     const payload = await fs.readJson(process.env.ATOMIST_PAYLOAD || "/atm/payload.json");

--- a/lib/secrets.ts
+++ b/lib/secrets.ts
@@ -15,11 +15,7 @@
  */
 
 import { GraphQLClient } from "./graphql";
-import {
-    CommandIncoming,
-    EventIncoming,
-    isCommandIncoming,
-} from "./payload";
+import { CommandIncoming, EventIncoming, isCommandIncoming } from "./payload";
 
 export type CredentialResolver<T> = (
     graphClient: GraphQLClient,

--- a/lib/steps.ts
+++ b/lib/steps.ts
@@ -15,11 +15,7 @@
  */
 
 import { Severity } from "@atomist/skill-logging";
-import {
-    CommandContext,
-    EventContext,
-    HandlerStatus,
-} from "./handler";
+import { CommandContext, EventContext, HandlerStatus } from "./handler";
 import { warn } from "./log";
 import { toArray } from "./util";
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     "typedoc": "^0.17.6",
     "typescript": "^3.8.2"
   },
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "directories": {
     "test": "test"
   },

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -16,10 +16,24 @@
 
 import * as assert from "assert";
 import * as fs from "fs-extra";
+import * as log from "../lib/log";
 import { createProjectLoader, gitHubComRepository } from "../lib/project";
 import { commit, createBranch, status } from "../lib/project/git";
 
 describe("project", () => {
+    let originalLogDebug: any;
+    before(() => {
+        originalLogDebug = Object.getOwnPropertyDescriptor(log, "debug");
+        Object.defineProperty(log, "debug", {
+            value: async () => {
+                return;
+            },
+        });
+    });
+    after(() => {
+        Object.defineProperty(log, "debug", originalLogDebug);
+    });
+
     it("should clone public repo", async () => {
         const p = await createProjectLoader().clone(
             gitHubComRepository({ owner: "atomist", repo: "skill", credential: undefined }),

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -16,15 +16,8 @@
 
 import * as assert from "assert";
 import * as fs from "fs-extra";
-import {
-    createProjectLoader,
-    gitHubComRepository,
-} from "../lib/project";
-import {
-    commit,
-    createBranch,
-    status,
-} from "../lib/project/git";
+import { createProjectLoader, gitHubComRepository } from "../lib/project";
+import { commit, createBranch, status } from "../lib/project/git";
 
 describe("project", () => {
     it("should clone public repo", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
     "test/**/*.ts"
   ],
   "exclude": [
-    ".#*
+    ".#*"
   ],
   "compileOnSave": true,
   "buildOnSave": false,


### PR DESCRIPTION
Add manually created `index.ts` to project.

I deliberately left out some internal functions and classes and not exported them. To make this clear, I created empty exports for internal files in the `index.ts` to not mistakenly think they were just forgotten to get exported. 

Not sure if that covers every use-case so far in skills, but it is a start IMHO. Interested in your feedback @ddgenome and @ipcrm.

I've migrated a skill to use the index: https://github.com/atomist-skills/github-auto-merge-skill/pull/9